### PR TITLE
Add Trigger Transitions for event based transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,9 +292,9 @@ But when is the right time for the state machine to finally change states? This 
 
 ## State Change Patterns
 
-The state machine supports two ways of changing states:
+The state machine supports three ways of changing states:
 
-1. Using `Transition` objects as described earlier
+1. Using `Transition` objects as described earlier. You can even have multiple transitions that connect the same two states. They are checked on every OnLogic call and can be seen as a type of polling.
    
    ```csharp
    fsm.AddTransition( new Transition(
@@ -304,7 +304,7 @@ The state machine supports two ways of changing states:
    ));
    ```
 
-2. Calling the `RequestStateChange` method: Instead of using Transition objects to manage transitions, each state can individually also manage its own transitions by directly calling the `RequestStateChange` method
+2. Calling the `RequestStateChange` method: Instead of using Transition objects to manage state changes, each state can individually also manage its own transitions by directly calling the `RequestStateChange` method.
    
    ```csharp
    fsm.RequestStateChange(state, forceInstantly: false);
@@ -323,6 +323,27 @@ The state machine supports two ways of changing states:
    ));
    ```
 
+3. Using "Trigger Transitions": These are normal transitions that are only checked when a certain trigger (an event) is activated.
+   
+   ```csharp
+   fsm.AddTriggerTransition(triggerName, transition);
+   ```
+   
+   **Example**
+   
+   ```csharp
+   // Flappy Bird Example
+   fsm.AddTriggerTransition(
+       "OnCollision",
+       new Transition("Alive", "Dead")
+   );
+   
+   // Later
+   fsm.Trigger("OnCollision");
+   ```
+
+Therefore UnityHFSM supports both polling-based and event-based transitions, as well as the feature to bypass the concept of transitions all together. That's pretty cool.
+
 There is also a slight variation of the `Transition` state change behaviour, that allows you to change to a specific state from any other state (a "global" transition as opposed to a "local" / "direct" transition). They have the same `forceInstantly` / `needsExitTime` handling as normal transitions.
 
 ```csharp
@@ -331,6 +352,12 @@ fsm.AddTransitionFromAny( new Transition(
     to,
     condition 
 ));
+
+// For Trigger Transitions
+fsm.AddTriggerTransitionFromAny(
+    triggerName,
+    transition
+);
 ```
 
 **Example**
@@ -341,6 +368,12 @@ fsm.AddTransitionFromAny( new Transition(
     "Dead",
     t => (health <= 0)
 ));
+
+// For Trigger Transitions
+fsm.AddTriggerTransitionFromAny(
+    "OnDamage",
+    new Transition("", "Dead", t => (health <= 0))
+);
 ```
 
 ## Control flow of OnLogic

--- a/README.md
+++ b/README.md
@@ -449,31 +449,3 @@ Simply inherit from the base class `StateBase` and override the methods you need
 ```
 
 More documentation coming soon...
-
-### Roadmap
-
-- [ ] Getting started / Installation guide
-
-**v1.6**
-
-- [x] HybridStateMachine for less code duplication
-
-- [x] State wrappers for running companion code with states
-
-- [x] Docstring documentation of HybridStateMachine
-
-- [ ] Docstring documentation of StateWrapper
-
-- [ ] Documentation for avoiding duplicate code by using the HybridStateMachine
-
-- [x] Improve code examples -> first FSM example with move towards player can be more concise
-
-**v1.7**
-
-- [ ] Dynamic state removal
-
-- [ ] More demos
-
-- [ ] Documentation for re-using state machines (by using functions to create FSMs)
-
-- [ ] Documentation of dynamically created state machines (and their use, e.g. wall jump -> has the player unlocked this ability? -> Don't add transitions if not)

--- a/src/StateMachine.cs
+++ b/src/StateMachine.cs
@@ -386,9 +386,11 @@ namespace FSM
 				}
 			}
 
-			for (int i = 0; i < activeTriggerTransitions.Count; i ++)
+			triggerTransitions = activeTriggerTransitions[trigger];
+			
+			for (int i = 0; i < triggerTransitions.Count; i ++)
 			{
-				TransitionBase transition = activeTriggerTransitions[i];
+				TransitionBase transition = triggerTransitions[i];
 				
 				if (TryTransition(transition))
 					return;

--- a/src/StateMachine.cs
+++ b/src/StateMachine.cs
@@ -152,11 +152,28 @@ namespace FSM
 			{
 				activeTransitions = noTransitions;
 			}
+			else
+			{
+				for (int i = 0; i < activeTransitions.Count; i ++)
+				{
+					activeTransitions[i].OnEnter();
+				}
+			}
 
 			activeTriggerTransitions = bundle.triggerToTransitions;
 			if (activeTriggerTransitions == null)
 			{
 				activeTriggerTransitions = noTriggerTransitions;
+			}
+			else
+			{
+				foreach (List<TransitionBase> transitions in activeTriggerTransitions.Values)
+				{
+					for (int i = 0; i < transitions.Count; i ++)
+					{
+						transitions[i].OnEnter();
+					}
+				}
 			}
 		}
 
@@ -226,6 +243,19 @@ namespace FSM
 		public override void OnEnter()
 		{
 			ChangeState(startState);
+
+			for (int i = 0; i < transitionsFromAny.Count; i ++)
+			{
+				transitionsFromAny[i].OnEnter();
+			}
+
+			foreach (List<TransitionBase> transitions in triggerTransitionsFromAny.Values)
+			{
+				for (int i = 0; i < transitions.Count; i ++)
+				{
+					transitions[i].OnEnter();
+				}
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
### New Feature: Trigger Transitions

Trigger Transitions = Transitions that are only checked when a trigger (an event) is activated.

These are really handy when a polling-based solution does not fit or is not efficient enough. Trigger Transitions let you effortlessly leverage the efficiency of event-based transitions, in combination with the full power of the existing high-level transition types.

At the same time this feature legitimises the use of a more efficient method for state and transition lookups, which greatly improves the performance of state changes **(Up to 50% increase in speed)**. 
The slowest parts in state changes are the dictionary lookups. Previously there were two dictionary lookups per transition (one for the state and one for the transition objects). To make trigger transitions faster, you would have had to cash the outgoing trigger transitions of a state, therefore causing a third dictionary lookup on every state change. Instead, these three items, the transitions, the state and the trigger transitions, are stored together in a `StateBundle`, which only requires one dictionary lookup every time it moves from one state to another.

**This release of the project is both the most feature rich and the most performant release.**