### PR TITLE
Fix KeyNotFoundException

### DIFF
--- a/src/StateMachine.cs
+++ b/src/StateMachine.cs
@@ -464,14 +464,15 @@ namespace FSM
 				}
 			}
 
-			triggerTransitions = activeTriggerTransitions[trigger];
-
-			for (int i = 0; i < triggerTransitions.Count; i ++)
+			if (activeTriggerTransitions.TryGetValue(trigger, out triggerTransitions))
 			{
-				TransitionBase<TStateId, TEvent> transition = triggerTransitions[i];
-				
-				if (TryTransition(transition))
-					return true;
+				for (int i = 0; i < triggerTransitions.Count; i ++)
+				{
+					TransitionBase<TStateId, TEvent> transition = triggerTransitions[i];
+
+					if (TryTransition(transition))
+						return true;
+				}
 			}
 			
 			return false;


### PR DESCRIPTION
Prevents KeyNotFoundException when firing a trigger with no transition.
The following code throws a KeyNotFoundException because there is no transition from `"TO"` to `"TO"`.

```cs
using FSM;
using UnityEngine;

public class Foo : MonoBehaviour
{
    private StateMachine fsm;

    private void Awake()
    {
        fsm = new StateMachine(this);
        fsm.AddState("FROM", new State(needsExitTime: true));
        fsm.AddState("TO", new State(needsExitTime: true));
        fsm.AddTriggerTransition("TO", new Transition("FROM", "TO", forceInstantly: true));
        fsm.AddTriggerTransition("FROM", new Transition("TO", "FROM", forceInstantly: true));
        fsm.SetStartState("TO");
        fsm.Init();
    }

    void Trigger()
    {
        fsm.Trigger("TO");
    }

    private void Start()
    {
        Invoke(nameof(Trigger), 3);
    }

    private void Update()
    {
        fsm.OnLogic();
    }
}
```