### PR TITLE
Call OnEnter after updating transitions and triggers

### DIFF
--- a/src/StateMachine.cs
+++ b/src/StateMachine.cs
@@ -158,20 +158,10 @@ namespace FSM
 				throw new FSM.Exceptions.StateNotFoundException<TStateId>(name, "Switching states");
 			}
 
-			activeState = bundle.state;
-			activeState.OnEnter();
-
 			activeTransitions = bundle.transitions;
 			if (activeTransitions == null)
 			{
 				activeTransitions = noTransitions;
-			}
-			else
-			{
-				for (int i = 0; i < activeTransitions.Count; i ++)
-				{
-					activeTransitions[i].OnEnter();
-				}
 			}
 
 			activeTriggerTransitions = bundle.triggerToTransitions;
@@ -179,14 +169,20 @@ namespace FSM
 			{
 				activeTriggerTransitions = noTriggerTransitions;
 			}
-			else
+
+			activeState = bundle.state;
+			activeState.OnEnter();
+
+			for (int i = 0; i < activeTransitions.Count; i++)
 			{
-				foreach (List<TransitionBase<TStateId, TEvent>> transitions in activeTriggerTransitions.Values)
+				activeTransitions[i].OnEnter();
+			}
+
+			foreach (List<TransitionBase<TStateId, TEvent>> transitions in activeTriggerTransitions.Values)
+			{
+				for (int i = 0; i < transitions.Count; i++)
 				{
-					for (int i = 0; i < transitions.Count; i ++)
-					{
-						transitions[i].OnEnter();
-					}
+					transitions[i].OnEnter();
 				}
 			}
 		}


### PR DESCRIPTION
Trigger does not work within OnEnter.
This is because OnEnter is called before activeTransitions and activeTriggerTransitions are updated, so the transition list and state do not match.
Therefore, OnEnter should be called after activeTransitions and activeTriggerTransitions are updated.

```cs
using FSM;
using UnityEngine;

public class Foo : MonoBehaviour
{
    private StateMachine stateMachine;

    private void Awake()
    {
        stateMachine = new StateMachine(this);

        stateMachine.AddState("Run", new State());
        stateMachine.AddState("Jump", new State(onEnter: s =>
        {
            Debug.Log(stateMachine.ActiveStateName);
            stateMachine.Trigger("ToGround");
            Debug.Log(stateMachine.ActiveStateName); // expect "Ground" but it's "Run"
        }));
        stateMachine.AddState("Ground", new State());

        stateMachine.AddTriggerTransition("ToJump", new Transition("Run", "Jump"));
        stateMachine.AddTriggerTransition("ToGround", new Transition("Jump", "Ground")); // expect transition
        stateMachine.AddTriggerTransition("ToGround", new Transition("Run", "Run")); // actual transition

        stateMachine.SetStartState("Run");

        stateMachine.Init();
        stateMachine.Trigger("ToJump");
    }
}
```

Output before modification
```
Jump
Run
```

Output after modification
```
Jump
Ground
```