### PR TITLE
Add OnActiveStateChanged event and unit tests.

### DIFF
--- a/Tests/TestActiveStateChangedEvent.cs
+++ b/Tests/TestActiveStateChangedEvent.cs
@@ -1,0 +1,56 @@
+using NUnit.Framework;
+using FSM;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FSM.Tests
+{
+    public class TestActiveStateChangedEvent
+    {
+        private StateMachine fsm;
+        private List<string> trackedStates;
+
+        [SetUp]
+        public void Setup()
+        {
+            fsm = new StateMachine();
+            trackedStates = new List<string>();
+        }
+
+        [Test]
+        public void Test_active_state_changed_event()
+        {
+            fsm.OnActiveStateChanged += state => trackedStates.Add(state != null ? state.name : "null");
+
+            fsm.AddState("A", new State());
+            fsm.AddState("B", new State());
+            fsm.AddState("C", new State());
+
+            fsm.AddTransition("A", "B");
+            fsm.AddTransition("B", "C");
+
+            fsm.SetStartState("A");
+            fsm.Init();
+
+            AssertTrackedStated(expected: new[] { "A" });
+
+            fsm.OnLogic();
+            AssertTrackedStated(expected: new[] { "A", "B" });
+
+            fsm.OnLogic();
+            AssertTrackedStated(expected: new[] { "A", "B", "C" });
+
+            fsm.OnExit();
+            AssertTrackedStated(expected: new[] { "A", "B", "C", "null" });
+        }
+
+        private void AssertTrackedStated(IEnumerable<string> expected)
+        {
+            if (!trackedStates.SequenceEqual(expected))
+            {
+                Assert.Fail($"Tracked active states is not equals with expected. Real: ({string.Join(',', trackedStates)}), Expected : ({string.Join(',', expected)})");
+            }
+        }
+    }
+}

--- a/Tests/TestActiveStateChangedEvent.cs.meta
+++ b/Tests/TestActiveStateChangedEvent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 595493d7152c49a19b6f406d6cb7559d
+timeCreated: 1684143774

--- a/src/StateMachine/StateMachine.cs
+++ b/src/StateMachine/StateMachine.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 /**
@@ -76,6 +77,8 @@ namespace FSM
 		private Dictionary<TEvent, List<TransitionBase<TStateId>>> triggerTransitionsFromAny
 			= new Dictionary<TEvent, List<TransitionBase<TStateId>>>();
 
+		public event Action<StateBase<TStateId>> OnActiveStateChanged;
+		
 		public StateBase<TStateId> ActiveState
 		{
 			get
@@ -162,6 +165,7 @@ namespace FSM
 			activeTriggerTransitions = bundle.triggerToTransitions ?? noTriggerTransitions;
 
 			activeState = bundle.state;
+			OnActiveStateChanged?.Invoke(activeState);
 			activeState.OnEnter();
 
 			for (int i = 0; i < activeTransitions.Count; i++)
@@ -340,6 +344,7 @@ namespace FSM
 				// By setting the activeState to null, the state's onExit method won't be called
 				// a second time when the state machine enters again (and changes to the start state)
 				activeState = null;
+				OnActiveStateChanged?.Invoke(activeState);
 			}
 		}
 


### PR DESCRIPTION
Usecase 
easily track ActiveState changing.

Simple Usage
`  
fsm.OnActiveStateChanged += (state)=> Debug.Log(state.name);
`

I didn't add invoking event method in ActiveState's setter for minimum code changing. I added it in StateMachine class's ChangeState method and OnExit method. but i am willing to fix it.