### PR TITLE
Fix Time.time access exception during deserialization

### DIFF
--- a/src/Util/Timer.cs
+++ b/src/Util/Timer.cs
@@ -12,7 +12,7 @@ namespace FSM
 
 		public Timer()
 		{
-			startTime = Time.time;
+			if(Application.isPlaying) { startTime = Time.time; }
 		}
 
 		public void Reset()


### PR DESCRIPTION
If a `State` or `State`-derived class is serialized for use in the inspector, then everytime scripts are compiled it will throw an exception from the public Timer() field being automatically initialized, which causes an access to Time.time, which can't be access during deserialization.