### PR TITLE
Add IActionable.HasAction() method

### DIFF
--- a/src/Base/IActionable.cs
+++ b/src/Base/IActionable.cs
@@ -9,6 +9,7 @@ namespace UnityHFSM
 	{
 		void OnAction(TEvent trigger);
 		void OnAction<TData>(TEvent trigger, TData data);
+		bool HasAction(TEvent trigger);
 	}
 
 	/// <inheritdoc />

--- a/src/StateMachine/HybridStateMachine.cs
+++ b/src/StateMachine/HybridStateMachine.cs
@@ -96,6 +96,12 @@ namespace UnityHFSM
 			base.OnAction<TData>(trigger, data);
 		}
 
+		public override bool HasAction(TEvent trigger)
+		{
+			return (actionStorage?.HasAction(trigger) ?? false)
+				|| base.HasAction(trigger);
+		}
+
 		/// <summary>
 		/// Adds an action that can be called with <c>OnAction()</c>. Actions are like the builtin events
 		/// <c>OnEnter</c> / <c>OnLogic</c> / ... but are defined by the user.

--- a/src/StateMachine/StateMachine.cs
+++ b/src/StateMachine/StateMachine.cs
@@ -781,6 +781,17 @@ namespace UnityHFSM
 			(activeState as IActionable<TEvent>)?.OnAction<TData>(trigger, data);
 		}
 
+        /// <summary>
+        /// Checks if currently active state has this action.
+        /// </summary>
+        /// <param name="trigger">Name of the action.</param>
+        /// <returns></returns>
+        public virtual bool HasAction(TEvent trigger)
+		{
+			EnsureIsInitializedFor("Running HasAction of the active state");
+			return (activeState as IActionable<TEvent>)?.HasAction(trigger) ?? false;
+		}
+
 		public StateBase<TStateId> GetState(TStateId name)
 		{
 			StateBundle bundle;

--- a/src/States/ActionState.cs
+++ b/src/States/ActionState.cs
@@ -67,6 +67,14 @@ namespace UnityHFSM
 		/// <typeparam name="TData">Type of the data parameter.</typeparam>
 		public void OnAction<TData>(TEvent trigger, TData data)
 			=> actionStorage?.RunAction<TData>(trigger, data);
+
+        /// <summary>
+        /// Checks if this action is defined / has been added.
+        /// </summary>
+        /// <param name="trigger">Name of the action.</param>
+        /// <returns></returns>
+        public bool HasAction(TEvent trigger)
+			=> actionStorage?.HasAction(trigger) ?? false;
 	}
 
 	/// <inheritdoc />

--- a/src/States/ActionStorage.cs
+++ b/src/States/ActionStorage.cs
@@ -89,5 +89,13 @@ namespace UnityHFSM
 		/// <typeparam name="TData">Type of the data parameter.</typeparam>
 		public void RunAction<TData>(TEvent trigger, TData data)
 			=> TryGetAndCastAction<Action<TData>>(trigger)?.Invoke(data);
+
+        /// <summary>
+        /// Checks if this action is defined / has been added.
+        /// </summary>
+        /// <param name="trigger">Name of the action.</param>
+        /// <returns></returns>
+        public bool HasAction(TEvent trigger)
+			=> actionsByEvent.ContainsKey(trigger);
 	}
 }

--- a/src/States/DecoratedState.cs
+++ b/src/States/DecoratedState.cs
@@ -94,6 +94,11 @@ namespace UnityHFSM
         	(state as IActionable<TEvent>)?.OnAction<TData>(trigger, data);
         }
 
+        public bool HasAction(TEvent trigger)
+        {
+            return (state as IActionable<TEvent>)?.HasAction(trigger) ?? false;
+        }
+
         public override string GetActiveHierarchyPath()
         {
         	return state.GetActiveHierarchyPath();

--- a/src/States/ParallelStates.cs
+++ b/src/States/ParallelStates.cs
@@ -193,6 +193,16 @@ namespace UnityHFSM
 			}
 		}
 
+		public bool HasAction(TEvent trigger)
+		{
+			foreach (var state in states)
+			{
+                if ((state as IActionable<TEvent>)?.HasAction(trigger) ?? false)
+					return true;
+			}
+			return false;
+		}
+
 		public void StateCanExit()
 		{
 			// Try to exit as soon as any one of the child states can exit, unless the exit behaviour


### PR DESCRIPTION
A method that checks if a state has the given action defined, or if the current state in a state machine has it defined. This can be used to easily create "default behaviors" that can be overridden by defining the action.

Basic example:
```
if (sm.HasAction(TestAction.Attack))
    sm.OnAction(TestAction.Attack);
else
    print(Time.time + ": Not attacking :(");
```

This is meant to be an alternative to [my other PR like this](https://github.com/Inspiaaa/UnityHFSM/pull/63). You can use the one you think would be most performant in most situations.