### PR TITLE
Fixed AnimatorController console error by making sure that all transi…

### DIFF
--- a/src/Visualization/HfsmAnimatorGraph.cs
+++ b/src/Visualization/HfsmAnimatorGraph.cs
@@ -548,6 +548,8 @@ public static class HfsmAnimatorGraph
 	{
 		animator.states = new ChildAnimatorState[0];
 		animator.stateMachines = new ChildAnimatorStateMachine[0];
+        animator.entryTransitions = new AnimatorTransition[0];
+        animator.anyStateTransitions = new AnimatorStateTransition[0];
 	}
 }
 }


### PR DESCRIPTION
Fixes #66.

While integrating #53, it seems that these lines were lost:

```
animator.entryTransitions = new AnimatorTransition[0];
animator.anyStateTransitions = new AnimatorStateTransition[0];
```

As a result, the transitions were not being properly cleared in the AnimatorController asset. This caused issues on subsequent runs for an existing AnimatorController.

This PR re-adds those lines into ClearAnimatorStateMachine.